### PR TITLE
Fix bug in dump function that incorrectly quoted primitive values

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,7 @@
 std = 'max'
 include_files = {
     'dump.lua',
+    'lib/undump.lua',
     'test/*_test.lua',
 }
 ignore = {

--- a/dump.lua
+++ b/dump.lua
@@ -297,11 +297,14 @@ local function dump(val, indent, padding, filter, udata)
     end
 
     -- dump value
-    local v, nodump = filter(val, 0, t, FOR_VAL, nil, udata)
-    if nodump == true then
-        return tostring(v)
+    local v = filter(val, 0, t, FOR_VAL, nil, udata)
+    t = type(v)
+    v = tostring(v)
+    if t == 'number' or t == 'boolean' or t == 'nil' then
+        return v
     end
-    return strformat('%q', tostring(v))
+    -- non number/boolean/nil values are converted to quoted string
+    return strformat('%q', v)
 end
 
 return dump

--- a/rockspecs/dump-scm-1.rockspec
+++ b/rockspecs/dump-scm-1.rockspec
@@ -1,13 +1,13 @@
 package = "dump"
 version = "scm-1"
 source = {
-    url = "git+https://github.com/mah0x211/lua-dump.git"
+    url = "git+https://github.com/mah0x211/lua-dump.git",
 }
 description = {
     summary = "stringified lua data structures, suitable for both printing and loading as chunk.",
     homepage = "https://github.com/mah0x211/lua-dump",
     license = "MIT/X11",
-    maintainer = "Masatoshi Teruya"
+    maintainer = "Masatoshi Fukunaga",
 }
 dependencies = {
     "lua >= 5.1",
@@ -15,7 +15,7 @@ dependencies = {
 build = {
     type = "builtin",
     modules = {
-        dump = "dump.lua"
-    }
+        dump = "dump.lua",
+    },
 }
 

--- a/test/dump_test.lua
+++ b/test/dump_test.lua
@@ -103,11 +103,12 @@ function testcase.dump_non_table_value()
     -- test that non-table values are dumped correctly
 
     -- Test basic value types
-    assert.equal(dump(nil), '"nil"')
-    assert.equal(dump(true), '"true"')
-    assert.equal(dump(false), '"false"')
-    assert.equal(dump(123), '"123"')
-    assert.equal(dump(123.45), '"123.45"')
+    assert.equal(dump(nil), 'nil')
+    assert.equal(dump(true), 'true')
+    assert.equal(dump(false), 'false')
+    assert.equal(dump(123), '123')
+    assert.equal(dump(123.45), '123.45')
+    assert.equal(dump(-123.45), '-123.45')
     assert.equal(dump("hello"), '"hello"')
 
     -- Test with custom filter
@@ -118,7 +119,7 @@ function testcase.dump_non_table_value()
         end
         return val
     end)
-    assert.equal(result, "test")
+    assert.equal(result, '"test"')
 end
 
 function testcase.dump_unnested_table()


### PR DESCRIPTION
Primitive types were being quoted as strings, making dump output invalid as Lua code. Fixed to return literal representations that can be properly evaluated back to original values.